### PR TITLE
Add support for "if" token

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -9,6 +9,5 @@
     "dflags-dmd" : ["-preview=markdown"],
     "subPackages" : ["example"],
     "dependencies" : {
-        "sumtype" : "~>1.0"
     }
 }

--- a/example/dub.json
+++ b/example/dub.json
@@ -1,23 +1,6 @@
 {
     "name": "example",
     "targetType": "executable",
-    "configurations" : [
-        {
-            "name": "example"
-        },
-        {
-            "name": "unittest",
-            "targetType": "executable",
-            "preBuildCommands": ["$DUB run --compiler=$$DC unit-threaded -c gen_ut_main -- -f bin/ut.d -d $DUB"],
-            "mainSourceFile": "bin/ut.d",
-            "excludedSourceFiles": ["main.d"],
-            "dependencies": {
-                "unit-threaded": "*"
-            }
-        }
-
-    ],
-
     "sourcePaths": ["."],
     "importPaths": ["."],
     "excludedSourceFiles": ["bin/ut.d"],

--- a/example/jsongrammar.d
+++ b/example/jsongrammar.d
@@ -12,7 +12,7 @@ import autoparsed.log;
 
 import std.typecons : Tuple;
 
-import sumtype;
+import std.sumtype;
 
 @Token {
   enum lcurly = '{';
@@ -82,6 +82,10 @@ struct JSONObject{
   }
 }
 
+import autoparsed.traits;
+static assert(isInstantiable!JSONValue);
+static assert(isInstantiable!JSONObject);
+
 @Syntax!(lbracket, RegexStar!(JSONValueSyntax, comma), Optional!(JSONValueSyntax), rbracket)
 struct JSONArray{
   private JSONValue[] data;
@@ -100,6 +104,9 @@ unittest{
   import std.algorithm;
   import std.conv : to;
   import autoparsed.recursivedescent;
+
+  JSONObject testObject;
+  JSONObject testObject2 = void;
 
   writeln("\n\nRUNNING\n\n");
   auto testString = `{"hello" : "world", "key" : 45, "anArray" :[1, "a string", {}]}`;

--- a/example/main.d
+++ b/example/main.d
@@ -7,7 +7,7 @@ void main(string[] args){
   import std.traits;
   import std.array;
   import std.algorithm;
-  import sumtype;
+  import std.sumtype;
 
   import sexpGrammar;
 

--- a/example/sexpGrammar.d
+++ b/example/sexpGrammar.d
@@ -10,7 +10,7 @@ import autoparsed.autoparsed;
 import autoparsed.lexer;
 import autoparsed.syntax;
 
-import sumtype;
+import std.sumtype;
 
 
 

--- a/source/autoparsed/autoparsed.d
+++ b/source/autoparsed/autoparsed.d
@@ -18,9 +18,10 @@ template tokensFromModule(alias Module){
 template tokenTypes(alias Module){
   import std.meta : staticMap;
   import std.traits : isType;
+  import autoparsed.traits;
 
   template wrap(alias T){
-    static if(!isType!T){
+    static if(!isType!T || !isInstantiable!T){
       alias wrap = TokenType!T;
     } else {
       alias wrap = T;
@@ -30,7 +31,7 @@ template tokenTypes(alias Module){
 }
 
 template TokenPayload(alias Module){
-  import sumtype;
+  import std.sumtype;
   alias TokenPayload = SumType!(tokenTypes!Module);
 }
 

--- a/source/autoparsed/lexer.d
+++ b/source/autoparsed/lexer.d
@@ -19,13 +19,13 @@ struct Lexer(alias Mod){
 
   import std.traits : fullyQualifiedName;
 
-  import sumtype;
+  import std.sumtype;
   import std.typecons : Nullable;
 
   mixin CTLog!("lexer for module: ", fullyQualifiedName!Mod);
   mixin CTLog!("TT for mod: ", tokenTypes!Mod);
   alias parseRule = OneOf!(tokenTypes!Mod);
-  mixin CTLog!("lexer parse rule types: ", parseRule);  
+  mixin CTLog!("lexer parse rule types: ", parseRule);
 
   ///
   this(const(char)[] bytes){
@@ -64,9 +64,9 @@ struct Lexer(alias Mod){
     }
 
   }
-  
+
 private:
   const(char)[] bytes_;
   Nullable!(parseRule.NodeType) front_;
-  
+
 }

--- a/source/autoparsed/recursivedescent.d
+++ b/source/autoparsed/recursivedescent.d
@@ -2,6 +2,7 @@ module autoparsed.recursivedescent;
 import autoparsed.syntax;
 import autoparsed.autoparsed;
 import autoparsed.log;
+import autoparsed.traits;
 
 import std.stdio;
 import std.conv : to;
@@ -12,7 +13,7 @@ import std.algorithm;
 import std.array;
 import std.range.primitives;
 
-import sumtype;
+import std.sumtype;
 
 ///Common type returned on a successful call to parse
 struct Payload(T){
@@ -78,13 +79,24 @@ unittest {
 
 
 template partOfStream(T, StreamElement){
+  mixin CTLog!("Checkgin if ", T, "is part of ", StreamElement);
+  static if(__traits(hasMember, StreamElement, "data")){
+    mixin CTLog!("Elem type: ", typeof(StreamElement.data));
+  }
   private template contains(T, Ts...) {
     enum isSame(U) = allSameType!(T, U);
     alias contains = anySatisfy!(isSame, Ts);
   }
 
+  static if(isInstantiable!T){
+    alias ToSearch = T;
+  } else {
+    alias ToSearch = TokenType!T;
+  }
+
   enum partOfStream = is(StreamElement == OneOf!Args.NodeType, Args...) &&
-    contains!(T, TemplateArgsOf!(StreamElement.ST));
+    contains!(ToSearch, TemplateArgsOf!(StreamElement.ST));
+  mixin CTLog!("POS result: ", partOfStream);
 }
 
 enum hasUDASafe(alias X, alias UDA) = __traits(compiles, hasUDA!(X, UDA)) && hasUDA!(X, UDA);
@@ -111,17 +123,23 @@ if(hasUDASafe!(T, Token) &&
   mixin CTLog!("Parser for already lexed Token `", T, "` from stream of type `", TokenStream, "`");
   RTLog("parsing token `", T.stringof, "` from stream: ", tokenStream);
 
-  alias PayloadType = Payload!T;
-  alias ResultType = ParseResult!(PayloadType, DefaultError);
+  static if(isInstantiable!T){
+    alias RealPayloadType = T;
+  } else {
+    alias RealPayloadType = TokenType!T;
+  }
 
+  alias PayloadType = Payload!RealPayloadType;
+  alias ResultType = ParseResult!(PayloadType, DefaultError);
+  mixin CTLog!("Return type: ", ResultType);
   if(tokenStream.empty) return ResultType(DefaultError("empty stream"));
   return tokenStream.front.match!(
-    (T t){
+    (RealPayloadType t){
       auto ret = ResultType(PayloadType(t));
       tokenStream.popFront;
       return ret;
     },
-    _ => ResultType(DefaultError( "looking for "~ T.stringof~ " but found "~ to!string(tokenStream.front)))
+    _ => ResultType(DefaultError( "looking for "~ RealPayloadType.stringof~ " but found "~ to!string(tokenStream.front)))
   );
 
 }
@@ -137,7 +155,12 @@ if(isInstanceOf!(TokenType, T)){
 }
 
 template SyntaxReturnType(T){
-  alias PayloadType = Payload!T;
+  static if(isInstantiable!T){
+    alias RealPayloadType = T;
+  } else {
+    alias RealPayloadType = TokenType!T;
+  }
+  alias PayloadType = Payload!RealPayloadType;
   alias SyntaxReturnType = ParseResult!(PayloadType, DefaultError);
 }
 
@@ -148,20 +171,29 @@ if(hasUDASafe!(T, Syntax) && !partOfStream!(T, typeof(tokenStream.front()))) {
 
   alias syntax = getUDAs!(T, Syntax)[0];
 
+
   mixin CTLog!("Parser for type `", T, "` with annotated constructor syntax`", syntax, "`");
   RTLog("parsing token `", T.stringof, "` with annotated constructor from stream: ", tokenStream);
+
+  static if(is(T == enum)){
+    mixin CTLog!("T is enum, type");
+    alias RealPayloadType = TokenType!T;
+  } else {
+    alias RealPayloadType = T;
+  }
+  mixin CTLog!("Real payload type: ", RealPayloadType);
 
   alias Seq = TemplateArgsOf!syntax;
   auto parsed =  parse!Seq(tokenStream);
 
   alias ParsedPayloadType = typeof(parsed).PayloadType;
 
-  alias PayloadType = Payload!T;
+  alias PayloadType = Payload!RealPayloadType;
   alias RetType = ParseResult!(PayloadType, DefaultError);
-
+  mixin CTLog!("PayloadType in parse w/syntax UDA ", RealPayloadType, " Ret Type: ", RetType);
   return parsed.data.match!(
     (typeof(parsed).PayloadType payload) =>
-      RetType(PayloadType(construct!T(parsed.getPayload.contents))),
+      RetType(PayloadType(construct!RealPayloadType(parsed.getPayload.contents))),
     _ => RetType(DefaultError(to!string(_))));
 }
 
@@ -248,7 +280,7 @@ if(isInstanceOf!(OneOf, OO)){
       TokenStream copy = tokenStream; //only advance the stream on success
       auto res = parse!T(copy);
       if(!res.isParseError){
-
+        mixin CTLog!("About to make OO Node with OO: ", OO, " and nodetype: " , typeof(OO.NodeType.data), " and the matching T was: ", T);
         auto oont = OO.NodeType(res.getPayload.contents);
         tokenStream = copy;
         return RetType(PayloadType(oont));
@@ -347,6 +379,7 @@ auto parse(TokenStream)(ref TokenStream tokenStream)
 
   alias TType = ElementType!TokenStream;
   alias TokensReplaced = ReplaceTokensRecursive!(TType, Ts);
+  mixin CTLog!("Replaced tokens: ", TokensReplaced);
   alias ParseOne(alias X) = ReturnType!( () => .parse!X(tokenStream)).PayloadType.Types;
   alias Values = EraseAll!(void, staticMap!(ParseOne, Ts));
 
@@ -504,10 +537,11 @@ template Matches(Src, Target){
   static if(is(Target : Src) || is(typeof(Src(Target.init)))){
     enum Matches = true;
   } else static if(is(Src == OneOf!OOArgs.NodeType, OOArgs...)){
+    mixin CTLog!("Src is OneOf, checking if any of its options match target");
     enum MatchOne(alias X) = isType!X && .Matches!(X, Target);
     enum Matches = anySatisfy!(MatchOne, OOArgs);
   } else static if(is(Target == OneOf!OOArgs.NodeType, OOArgs...)){
-
+    mixin CTLog!("Target is OneOf, checking if any of the src types match");
     enum MatchOne(alias X) = isType!X && .Matches!(Src, X);
     enum DirectMatch = anySatisfy!(MatchOne, OOArgs);
 
@@ -550,6 +584,8 @@ struct Wrap(T...){}
 enum size_t SkipArg = -2; //this syntax element shouldn't get passed to a constructor
 //probably a literal token
 
+///Cargs are the constructor arguments to the type we want to create
+///Targs are the types part of the @Syntax annotation
 template ArgRanges(CA, TA, size_t Ci){
 
   /*
@@ -638,6 +674,7 @@ template ArgRanges(CA, TA, size_t Ci){
   } else {
     static if(Matches!(Cargs[0], Targs[0])){
       //Ti will be passed for Ci
+      mixin CTLog!("First Carg: ", Cargs[0], " matches first Targ: ", Targs[0]);
       enum size_t[] ArgRanges = [Ci] ~
         .ArgRanges!(Wrap!(Cargs[1..$]), Wrap!(Targs[1..$]), Ci + 1);
     } else  {
@@ -703,7 +740,12 @@ auto simplifyPayload(bool KeepTokens = false, T)(T t){
 }
 
 auto make(T, Args...)(Args args){
-  static if(is(T == class)){
+
+  mixin CTLog!("Make: ", T, " args: ", Args);
+  static if(isInstanceOf!(TokenType, T)){
+    mixin CTLog!("making enum: ", T);
+    return T.init;
+  } else static if(is(T == class)){
     return new T(args);
   } else {
     return T(args);
@@ -716,41 +758,46 @@ T construct(T, Args)(Args args){
   mixin CTLog!("calling construct to make a ", T, " from ", Args);
   RTLog("calling construct to make a ", T.stringof, " from ", args);
 
-  auto simplified = simplifyPayload(args);
-  alias Stype = typeof(simplified);
-
+  alias Stype = ReturnType!(simplifyPayload!(false, typeof(args)));
   mixin CTLog!("simplified type of ", Args, " is ", Stype);
 
-
-  static if(is(Stype : T)){
-    return make!T(simplified);
+  static if(is(Stype: void)){
+    return make!T();
+    mixin CTLog!("made a ", T, " from void");
   } else {
 
-    alias Cargs = CArgs!T;
+    Stype simplified = simplifyPayload(args);
 
-    static if(!isTuple!Stype){
-      //one arg simplified type, better be a 1 arg constructor
-      static assert(Cargs.length == 1, "One arg simplified type");
-      return make!T(convert!(Cargs.Types[0])(simplified));
+    static if(is(Stype : T)){
+      //SType convertable to T, so have Make do the conversion
+      return make!T(simplified);
     } else {
 
+      alias Cargs = CArgs!T;
 
-      enum AR = ArgRanges!(Cargs, Stype, 0);
+      static if(!isTuple!Stype){
+        //one arg simplified type, better be a 1 arg constructor
+        static assert(Cargs.length == 1, "One arg simplified type");
+        return make!T(convert!(Cargs.Types[0])(simplified));
+      } else {
 
-      Cargs cargs;
-      static foreach(i, ar; AR){
 
-        static if(isArray!(typeof(cargs[ar]))){
-          cargs[ar] ~= convert!(Cargs.Types[ar])(simplified[i]);
-        } else {
-          cargs[ar] = convert!(Cargs.Types[ar])(simplified[i]);
+        enum AR = ArgRanges!(Cargs, Stype, 0);
+
+        Cargs cargs;
+        static foreach(i, ar; AR){
+
+          static if(isArray!(typeof(cargs[ar]))){
+            cargs[ar] ~= convert!(Cargs.Types[ar])(simplified[i]);
+          } else {
+            cargs[ar] = convert!(Cargs.Types[ar])(simplified[i]);
+          }
         }
-      }
 
-      return make!T(cargs.expand);
+        return make!T(cargs.expand);
+      }
     }
   }
-
 }
 
 template ReplaceTokenRecursive(Replacement, alias T)

--- a/source/autoparsed/syntax.d
+++ b/source/autoparsed/syntax.d
@@ -1,5 +1,8 @@
 module autoparsed.syntax;
 
+import autoparsed.log;
+import autoparsed.traits;
+
 ///UDA type for annotating constructors as grammar rules
 struct Syntax(T...){
   alias Elements = T;
@@ -17,11 +20,19 @@ enum Token;
 ///Wrapper type necessary for value tokens '(', ')', whitespace, etc
 struct TokenType(alias T){
   import std.traits : isType;
+  mixin CTLog!("insantiating TokenType of ", T);
 
   static if(isType!T){
+    mixin CTLog!(T, "is a type!");
     alias type = T;
-    T value;
+    static if(isInstantiable!T){
+      mixin CTLog!("and", T, "is instantiable");
+      T value;
+    } else {
+      mixin CTLog!("but", T, "is not instantiable");
+    }
   } else {
+    mixin CTLog!("it's NOT a type!");
     alias type = typeof(T);
     enum value = T;
   }
@@ -42,9 +53,10 @@ struct OneOf(Ts...){
       pragma(msg, "type provided: " ~ fullyQualifiedName!Ts[0]);
     }
   }
-  import sumtype;
+  import std.sumtype;
+  import autoparsed.traits;
   template Wrap(alias T){
-    static if(!isType!T) {
+    static if(!isType!T || !isInstantiable!T) {
       alias Wrap = TokenType!T;
     } else {
       alias Wrap = T;

--- a/source/autoparsed/traits.d
+++ b/source/autoparsed/traits.d
@@ -1,0 +1,29 @@
+module autoparsed.traits;
+
+import autoparsed.log;
+
+template isInstantiable(T){
+  mixin CTLog!("Checking if ", T, " is instantiable");
+  //enum isInstantiable = __traits(compiles, (){T x = void;});
+  import std.traits;
+  //types which are not enums (so, classes, basic types) are instantiable
+  //enum types are instantiable if they have at least one member
+  enum isInstantiable = isType!(T) && (!is(T == enum) || __traits(allMembers, T).length > 0);
+  mixin CTLog!("result: ", isInstantiable);
+}
+
+
+unittest {
+  static assert(isInstantiable!int);
+
+  struct S{}
+  struct T{int x;}
+  enum E;
+  enum F { f }
+
+  static assert(isInstantiable!S);
+  static assert(isInstantiable!T);
+  static assert(!isInstantiable!E);
+  static assert(isInstantiable!F);
+
+}


### PR DESCRIPTION
Add support for a parsable enum token ("if" for the C-like language).  Major changes were wrapping "uninstantiable" types (enums with no members) with TokenType.  Probably some duplicated checks/TokenType wrapping issues to be refactored later.
